### PR TITLE
Add assertion to ensure task list is not null

### DIFF
--- a/src/main/java/com/tanboonji/duke/Duke.java
+++ b/src/main/java/com/tanboonji/duke/Duke.java
@@ -50,6 +50,8 @@ public class Duke {
             ui.print(e.getMessage());
         }
 
+        assert(taskList != null);
+
         ui.greet();
     }
 


### PR DESCRIPTION
Task list is assumed to be either loaded with tasks from saved data or empty if saved data is not found.

Add assertion to esure task list is either of the two mentioned cases above and is not pointing to a null value.
A task list pointing to a null value will cause the program to run into an uncatched NullPointerException.